### PR TITLE
Add PDF accessibility guide

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -37,8 +37,13 @@
       This site provides guidance on accessibility features for vocational
       rehabilitation services. Explore how inclusive design opens doors for all
       users.
-    </p>
-  </section>
+      </p>
+      <p>
+        <a href="pdf-accessibility.html">
+          Learn how accessible PDFs help you meet the latest WCAG 2.2 guidelines
+        </a>
+      </p>
+    </section>
 
   <section>
     <h2>What is Accessibility?</h2>

--- a/site/pdf-accessibility.html
+++ b/site/pdf-accessibility.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>PDF Accessibility</title>
+  <link rel="stylesheet" href="styles.css" />
+  <script src="scripts/accessibility.js" defer></script>
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to Content</a>
+  <header>
+    <h1>PDF Accessibility</h1>
+    <nav>
+      <ul>
+        <li><a href="index.html">Home</a></li>
+        <li><a href="digital-tools.html">Digital Tools</a></li>
+        <li><a href="user-experience.html">User Experience</a></li>
+        <li><a href="training.html">Training</a></li>
+        <li><a href="future-accessibility.html">Future Tech</a></li>
+        <li><a href="policies.html">Policies &amp; Compliance</a></li>
+        <li><a href="about.html">About</a></li>
+        <li><a href="resources.html">Resources</a></li>
+        <li><a href="blog.html">Blog</a></li>
+        <li><a href="contact.html">Contact</a></li>
+      </ul>
+    </nav>
+  </header>
+  <main id="main">
+    <section>
+      <h2>Why Accessible PDFs Matter</h2>
+      <p>
+        PDF documents are widely used for forms, reports and training materials.
+        Making them accessible ensures people using screen readers or other
+        assistive technologies can navigate the content.
+      </p>
+    </section>
+    <section>
+      <h2>WCAG 2.2 Guidance</h2>
+      <p>
+        Follow the latest <a href="https://www.w3.org/WAI/WCAG22/">WCAG 2.2</a>
+        recommendations when creating PDFs. Provide meaningful headings, alt text
+        for images and accessible form fields so everyone can read them.
+      </p>
+    </section>
+    <section>
+      <h2>Basic Checklist</h2>
+      <ul>
+        <li>Tag all headings and lists</li>
+        <li>Use descriptive link text</li>
+        <li>Ensure sufficient color contrast</li>
+        <li>Include document language and title metadata</li>
+      </ul>
+    </section>
+  </main>
+  <footer>
+    <p>&copy; 2024 Accessibility Resources</p>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a highlight link to PDF accessibility in hero
- create `pdf-accessibility.html` with WCAG 2.2 guidance

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684137e41868832a95a4bd7b626f8090